### PR TITLE
Removed check for null texture in Graphic_MultiMask

### DIFF
--- a/Source/Graphic_MultiMask.cs
+++ b/Source/Graphic_MultiMask.cs
@@ -122,11 +122,6 @@ namespace GradientHair
                 }
                 else
                 {
-                    if (!(array[3] != null))
-                    {
-                        Log.Error("Failed to find any texture while constructing " + GraphicPath + ". Filenames have changed; if you are converting an old mod, recommend renaming textures from *_back to *_north, *_side to *_east, and *_front to *_south.");
-                        return;
-                    }
                     array[0] = array[3];
                     drawRotatedExtraAngleOffset = 90f;
                 }


### PR DESCRIPTION
Hi!

Following the discussion about the current bug where bald pawns cause other sprites to crash I created a simple fix

I tested with my save and everything seems to work but it wasn't extensive and there may still be some bugs